### PR TITLE
fix(sops): use ssh for admin keys

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v26
+      - uses: cachix/install-nix-action@v31
         with:
           # Helps avoid rate limiting
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v26
+      - uses: cachix/install-nix-action@v31
         with:
           # Helps avoid rate limiting
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v26
+      - uses: cachix/install-nix-action@v31
         with:
           # Helps avoid rate limiting
           github_access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,6 +1,7 @@
 keys:
   - &backup age14h3mwuj74khf4vu75a9mqy7hawc2pej8yqrqw5g55qcx6djup55qydcvmc
-  - &admin-dotboris age16lldqqyqqy6rw4zerw6kxr5x8dygt8apag8ve7n42n6me74mk4nseyvm3l
+  - &admin-dotboris-desktop ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJSVAavmM8Tz004E0GYZBerdouuquNldm8yozz76ZUw8
+  - &admin-dotboris-foxtrot ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK9QlBQ++xvislNNi4L2hkYpNHBL6MjrAkVhMRhUrOtg
   - &host-homelab age1drttm3pedzu63pwahgfjk0f2za0ywu57dec0e5sh3nc59vfm55xqzph4zm
   - &host-homelab-test age1uxn8hz7fv4h05l4uhtshpxkylv4krfmekc8ancuur682djmnm9asmgs8ma
 
@@ -9,14 +10,16 @@ creation_rules:
     key_groups:
       - age:
           - *backup
-          - *admin-dotboris
+          - *admin-dotboris-desktop
+          - *admin-dotboris-foxtrot
           - *host-homelab
 
   - path_regex: '^hosts/homelab-test/secrets.sops.yaml$'
     key_groups:
       - age:
           - *backup
-          - *admin-dotboris
+          - *admin-dotboris-desktop
+          - *admin-dotboris-foxtrot
           - *host-homelab-test
 
 stores:

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -34,14 +34,14 @@ The backup key should only be used to add a new key to the secrets. It should ne
 
 First, you'll need to configure your key in `.sops.yaml`:
 
-1. Under `keys:` add your public age key: `- &alias age...`
+1. Under `keys:` add your public ssh key: `- &alias ssh...`
 1. For each applicable creation rule, add the key to the key groups
 
 Here's what it looks like all put together:
 
 ```yaml
 keys:
-  - &my-key-alias age...
+  - &my-key-alias ssh...
   - ... # other keys
 
 creation_rules:

--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,11 @@
     };
     callPackage = path: overrides: pkgs.callPackage path {inherit inputs;} // overrides;
   in {
-    formatter.${system} = pkgs.alejandra;
+    formatter.${system} = pkgs.writeShellApplication {
+      name = "alejandra-format-repo";
+      runtimeInputs = [pkgs.alejandra];
+      text = "alejandra .";
+    };
     devShells.${system}.default = pkgs.mkShell {
       packages = [
         pkgs.nil

--- a/hosts/homelab-test/secrets.sops.yaml
+++ b/hosts/homelab-test/secrets.sops.yaml
@@ -22,40 +22,46 @@ backups:
       keyId: ENC[AES256_GCM,data:TMjysmqvVfxRoCwvBmtGvSqaslbhiNt67A==,iv:6MLzek7oKXnC4xYsR/kht1sbR/ZNYHECv6Yf4YGYMdc=,tag:LpuLYhDJIwpKHDAnXCruQg==,type:str]
       key: ENC[AES256_GCM,data:6B1hvTYC7lULKIyn3bnZl4M4y5pRUdeBpiH05MeVSg==,iv:TxJ2sCZjlynNPFJwtu4lgituMtrTdZlOEY2+RaIOf1k=,tag:bK6XnYdXH5VDXfjrR8dfSw==,type:str]
 sops:
-  kms: []
-  gcp_kms: []
-  azure_kv: []
-  hc_vault: []
   age:
     - recipient: age14h3mwuj74khf4vu75a9mqy7hawc2pej8yqrqw5g55qcx6djup55qydcvmc
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyZ2tWTlNKd3V6R1N6M3Ri
-        bXZ0RnVEWFlxQk1TZzlTUnlRVHVzV0JhQ0hFCnhQb2ZmRmZXQ0dkMXpxSldjcUlp
-        MU56Vi9ra0NYMUM3aHBubkRhNnpNaE0KLS0tIDZWSGp0MDI2MmF3QnpKWEE5V1M4
-        WDBGUmw3MlV5ZHByMXg1b2IrVEVCa1UKbqrqHmEL7DkuFW9Q0Nf2gaaPb61QQzJL
-        zJy2L9b5QkuYDKhZsmvO8qQlSwflMAQutTOxYa+e2r7aNM1J3Ih5rQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsRmNPTElwWG1BWXhQMzVk
+        RGNLaFdIRWM1blVzU3JiV2JtSEN4M2ZPYldrCktjUkJ0c0xEeFRUTFdrRTdNYnF3
+        enZTOWptTkpDNXFhSXJIalY3YkFWczAKLS0tIGFkZnlHMjZmeHBDY2ZtbStMS0JW
+        aEVGNGx1cGMyWlNDRW8rR1k3cHIyZE0KXldWE8xmYFW4KK+bPF1QfIQnaeu+xvMo
+        Vkp5zuXeXNvj9n3xHaxm3Y63BILGNNZ/Bmr9MiUHCM8b2klhbC7jkw==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age16lldqqyqqy6rw4zerw6kxr5x8dygt8apag8ve7n42n6me74mk4nseyvm3l
+    - recipient: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJSVAavmM8Tz004E0GYZBerdouuquNldm8yozz76ZUw8
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwOC9jbnV5cXlyK25kRGhG
-        QnZRVlNLVnIvTko5d05lZTVVVzA0a24wREV3Ci9qTVJiVTF2aEhUaENmWFBuVEVt
-        MTBsbUtiUnh5d3BTaG1mSXN5M0dPZjQKLS0tIDFDRnkrNm1vRmJtdGNZcnBXOUdF
-        cHkwTjZZUUJXei9UTEx1N1pHWWZMMG8KRtud7/F+WG/BMyaB7ehlnJrevHttbLpT
-        6Ald95LCdWxlPUnsgsR0jcuNdO1PY+bzrq7RdKNL4/4T0qQFFpdGqQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNzaC1lZDI1NTE5IDlGSUtpZyBRdmh6
+        SVZxaExVdnd4TzdBK2MzNmdodnJlNlZyeUNxRkZTTndNT2ZYQVgwCk1CLy9XN2pI
+        ZHJzdGdrNDZCWENQbURTSkZDM3ZmOHBjSXYxZWhpcTVGa2cKLS0tIFRiRExtMzg0
+        UEFBQnMyNlpFelhhUzZkTVlOZ0s0YTdFS1V2eVFCeG1QR28KE23dS1dk4Bnygzo9
+        Gvjtzg1Q10R4DALXZzt8HZxaq4c1icNgAtn6FQKuwopj2dy4UAn5q9CQP5QL5i2i
+        W4Tg6A==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK9QlBQ++xvislNNi4L2hkYpNHBL6MjrAkVhMRhUrOtg
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNzaC1lZDI1NTE5IGdVS205USBIbGU1
+        cnVMY2NQYnJLcVpnSXVNQXVZVlE1SEloWGl3K2NMeXd4NXROQkZFCjhyV2V4ZU5H
+        aHZWN0s1QXZKT2g3SWdRcUp3eTM2aWxxYjNCZGNlVmc5ZFEKLS0tIHUyQTVpYlFv
+        cjBNa3U4cjJlOFZCN2pZTVJpNGZDdTJsVnBxaFJwS1FLNXMKsKNteXlKGH4b6jyj
+        TGcXee9RdoCntDOziWd2DmvuYTqqpiClk0xj2gt/TUWDQTfN3IwOcI6s/UK5UWqz
+        22qTQw==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1uxn8hz7fv4h05l4uhtshpxkylv4krfmekc8ancuur682djmnm9asmgs8ma
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZZ0pNQXVtUEtwS2dJWFZn
-        WExQbXlTL1BwcFR0ak0yRFBISUlUeG93M0dzCnBjWWt3RktpYWlvenlGNk45emNm
-        MlZLTXkyNkhGdXdYOFFYWFYwbS9NRUkKLS0tIGx1UzJDdEtpQU9YRU5CU1Rvd3pY
-        eVhGVCs5K2I5QnQ0alpvMlgxNlhWOGMKtYPAFXyvthWzs81LIqnhat71flk3ha2K
-        wsBV/6cm6LEPU9bvdEujVx5Dgq/yJZZDVp4rkq/h3UB5u+MTT2g8Uw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0YlFJRWF5WERYbS9Yc3NE
+        VWhHRTh0c2poc1NEWWdrY2pYOE1nSDMvS24wClFDd25qVlRPSERqS3BCajFGMnJj
+        MGNZcEFlRXhlYXJDMlF3a0JYdTRPSDAKLS0tIFhpdjRlUkFScGVJdHRseERNbzhC
+        cTJHK3JsRTd0bDEwOTZ4aENGbVNHWDQK0BnDNc0so/frBLyxs7Tw7XZitNriAHhg
+        nxZrpt7DjGrF5knNPBF28iIeZ2CVFm7B3IelJLcwN9lUXEnpSNQLuw==
         -----END AGE ENCRYPTED FILE-----
   lastmodified: "2024-12-21T13:32:26Z"
   mac: ENC[AES256_GCM,data:e+Z4OaVqK+Q8oMye7gmnJhy/ZQjNCQSdDDh1golxUmqgyPtaN2UWpbT2sZ5wwQY+/UINRhp/mVmkbDT8aqpwi7wZms4beCT1D8lgvC3EaHEkhFjqXTVowIAtznup+dpfjCifH2O0XC5HzHJDak/fNX4XDkhPNGUbJ2M0WvMpohw=,iv:nfbbnNtLRvD0jba+4yzU8YK/9QLdIWJ55PsKrzPJ+M8=,tag:bv5rq904RDd9Kyh52/4JbA==,type:str]
-  pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.9.1

--- a/hosts/homelab/secrets.sops.yaml
+++ b/hosts/homelab/secrets.sops.yaml
@@ -22,40 +22,46 @@ backups:
       keyId: ENC[AES256_GCM,data:qlWmhWZiXqd2L4tTW1uhPwR177QQnmGxaQ==,iv:8MQCewS1InTI9YKytAoN8nTTJArZxluYDWl61cZecLs=,tag:wuMbP1ITyesCpEtSJjd+Mg==,type:str]
       key: ENC[AES256_GCM,data:B5a8DpdkOWt5h6Uu91N8jw5w5387n1UUFzpi9kJR4w==,iv:ppj0X9aOd6PHsOZBuFhvlwhpek/TbSWSAsdX8pUNHV8=,tag:M37JpybqYt3wAifly2miBA==,type:str]
 sops:
-  kms: []
-  gcp_kms: []
-  azure_kv: []
-  hc_vault: []
   age:
     - recipient: age14h3mwuj74khf4vu75a9mqy7hawc2pej8yqrqw5g55qcx6djup55qydcvmc
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxcU5pNWNWa1NlSjBIVDUr
-        SncvMGg0em1YTHBSS25vVFVCazVBMFhpeWpRClJmV3NJNmtDOStFMkdzMzA3TjFu
-        enFueEF1cFA5cnVVZjNPZ2Q4YjBQQW8KLS0tIFB5QnFEdnlRbnRNdXU2aklZYVBj
-        Ymo2ZDBkaDQyY0p6K1VOdTVoU2tzeGcKIs8zBhokd+qa95CttDQcC3RzorPyPQmb
-        X6f1PKZ6YqraEpUcLDsCbByB0yf3ThNQVJUrsXp9vGuLED7THIUJSw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPSFo2RFYrU1pwN2lFdVZ1
+        VmdSQjdWYnJEcDhadWRTbVJ3TGJrNEYzSDI0CnV2YWtoaDhPZStnekhUSFp5TWts
+        V1pRY3ltSTBKNWtlOUtGNjQzd0xVeUEKLS0tIG9TckpJVk8xeVVHamdyZ2FCUHp3
+        bk9XM0RCS29VSmQwT3lVL2ZieVF1WWMKazTGAIvbi40Xg/ld12fOqsAFxloZPKv7
+        bAAF0soAED0FsahnIuoRUbQlKVbhjuCgn/T8gftfhZYDKwxxr3kXTw==
         -----END AGE ENCRYPTED FILE-----
-    - recipient: age16lldqqyqqy6rw4zerw6kxr5x8dygt8apag8ve7n42n6me74mk4nseyvm3l
+    - recipient: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJSVAavmM8Tz004E0GYZBerdouuquNldm8yozz76ZUw8
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6UWRham5lSlpUc1JVY244
-        QmRjczBFdUZISVFKYm5YT0dENllRTW1jM1ZVCkFadzNVZmxtZDFJN2xBSGR3cnJQ
-        a1Fvb0VTU2I5N1h5OWo3WFc0UkJvZmMKLS0tIDJqNU5nRmN5aWszOEQ2ajB1OHRR
-        SGxhc2VtTUVqd1phT3JHVlNXQ0c0a1UKwAAE/0srGYZ1nKDcFmjcWRZhC+eewgsI
-        LG2MLM3nfS4IfbncCCiMgBdaPoubF6B6lV3RDDbipKDACwlYtvNCIg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNzaC1lZDI1NTE5IDlGSUtpZyBWNUFa
+        WkZPRTcwemhiMURmRU5hN0JkUUlzMFpRaHg5OXUrWEVQdURzS0Q0CmxiSlJNY09t
+        L0V4S1FLLzNCcXVLVmdreWUvc05lQ0xRbDE3R2dqcGIyZEkKLS0tIFdSTDNla0Ez
+        d3I0T0E0MVJvWlhkMUN3Z0RBcVQ5Q3V2Z0kwL1pmUm1veVkKNgRJWxDcsZc9zHlX
+        H9FFesfXs41VHvvTcC192OmDmyQ90em6+aW8ec4gjTj+u76e2wY7CBUpUtMuFtxG
+        QsnV2A==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK9QlBQ++xvislNNi4L2hkYpNHBL6MjrAkVhMRhUrOtg
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNzaC1lZDI1NTE5IGdVS205USBST2w5
+        UzNYUkQ1eFJkVVo5VXcrVGF3bTJoQmVKVDlHcGVZTllqSGdpNVR3CnBqVlNFOEV6
+        RW4rRFBLc1k0c1p6WDFYaHh2dVVBZ0R6MmVxZ2ZrWmtxYlkKLS0tIDZyYmZZSzhZ
+        ZFNoN2Y3ME8wSVpwT0prR2lxeXNRTW5GTmo3VUtGS2I4VXcK1XJD5cYj0KGZQ/Ov
+        VLLFvU6ydb00f5qsTsyYBBAaxpEpy58meHXsyRE3+Z0nbE8Xl0iCloZLeDxoFwJ7
+        tThV0Q==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1drttm3pedzu63pwahgfjk0f2za0ywu57dec0e5sh3nc59vfm55xqzph4zm
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1OW5CRFZuTmxWZWNESjVk
-        S0lKU0RJQmQ0ZXpNa0pOWERBSFZwZWxVY1NBCllUMjNMVkxkekd4czZxWm8vRklJ
-        UGZRVURzcUl5M3R0bmhpT0NkTmdIK00KLS0tIGJ2cG5NL1N1bGt1RjdxYXplZFhJ
-        MHZaUUpGNGlJSm5WSy9YSmhnQ3FMQVEKqKf7r2XFDqm9FSKuQ6TolaDOASuN3Zgt
-        3BRf9xrxZCZNnvUz3T8fctsdTrzWDBZq1/dm6X876YcnZ/RoVqovnA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvbndmS3lBOGhHSnU5dTdI
+        RXZkVkJCMkpxdWx0Z3QyaGY1ZS9QKzZZQ25RCk83Q0MrcW91SWZORnNsN0I0ZlpX
+        dmZPdVJ4QktyOVcrR1VFUUhxMVhXZVEKLS0tIFN4aXpvVXVOdndJZFBiRXkrR1N1
+        UmhUM1ZobU5oclpWaDBmUjZTWkFYbkUKtARjPDn5szn0IS4zolecUJk3NMhIKjvv
+        9+Lk0TXu5VupX31bYjk6ZuFQ6uluwepS5s4N+jpmtUp3r2rQ9/Xm/A==
         -----END AGE ENCRYPTED FILE-----
   lastmodified: "2024-12-21T21:43:15Z"
   mac: ENC[AES256_GCM,data:x+kY1UVu7ZzPxqFhYzTpFPk96iBZYQUuakMQ5K96qpvzwB3GFa0whO6akedGVy5g1sRTAQqWZCy4WDlpd0ZaMiu9Gf6ry9ogxVZtGFluO8psIzM4JsiXycbXVXau1jxI2kC34QGrErwgK5L+Beuy+p5Sv+PiYsuoyGNUpQm6OcU=,iv:cJT4wZrjjVMy9bjK6fGfLNZ59qbeZjXfaiRxBYXs8K0=,tag:qzTCoG+7Nt+Ozm2Q80yI8w==,type:str]
-  pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.9.1


### PR DESCRIPTION
SSH keys are nicer in this context because they have a passphrase unlike age keys.