### PR TITLE
feat(nixos): update to 25.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765326679,
-        "narHash": "sha256-fTLX9kDwLr9Y0rH/nG+h1XG5UU+jBcy0PFYn5eneRX8=",
+        "lastModified": 1765794845,
+        "narHash": "sha256-YD5QWlGnusNbZCqR3pxG8tRxx9yUXayLZfAJRWspq2s=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "d64e5cdca35b5fad7c504f615357a7afe6d9c49e",
+        "rev": "7194cfe5b7a3660726b0fe7296070eaef601cae9",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1765495779,
-        "narHash": "sha256-MhA7wmo/7uogLxiewwRRmIax70g6q1U/YemqTGoFHlM=",
+        "lastModified": 1765835352,
+        "narHash": "sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "5635c32d666a59ec9a55cab87e898889869f7b71",
+        "rev": "a34fae9c08a15ad73f295041fec82323541400a9",
         "type": "github"
       },
       "original": {
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764589946,
-        "narHash": "sha256-W8C9UnclS2IAvSuAYcvG1w+H/kVaqVE5XZNVh+fICH0=",
+        "lastModified": 1765793013,
+        "narHash": "sha256-kdTr/eK0ooWCwdMy0/4b2Elcy/UMI080E7s3gMiniII=",
         "owner": "nix-community",
         "repo": "nixos-images",
-        "rev": "ec7cd3c865f01906e6d023f8942299ad817f84cd",
+        "rev": "51a3afa20be1eceb6aca99e211229145dbb39a05",
         "type": "github"
       },
       "original": {
@@ -133,11 +133,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765311797,
-        "narHash": "sha256-mSD5Ob7a+T2RNjvPvOA1dkJHGVrNVl8ZOrAwBjKBDQo=",
+        "lastModified": 1765762245,
+        "narHash": "sha256-3iXM/zTqEskWtmZs3gqNiVtRTsEjYAedIaLL0mSBsrk=",
         "owner": "NixOs",
         "repo": "nixpkgs",
-        "rev": "09eb77e94fa25202af8f3e81ddc7353d9970ac1b",
+        "rev": "c8cfcd6ccd422e41cc631a0b73ed4d5a925c393d",
         "type": "github"
       },
       "original": {
@@ -149,11 +149,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1761765539,
-        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
+        "lastModified": 1765674936,
+        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
+        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
         "type": "github"
       },
       "original": {
@@ -180,11 +180,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765553226,
-        "narHash": "sha256-Ii16Nq5jL2wURXpV3D3tOM3vPpbKh18roHLkyZCHK4Q=",
+        "lastModified": 1765836173,
+        "narHash": "sha256-hWRYfdH2ONI7HXbqZqW8Q1y9IRbnXWvtvt/ONZovSNY=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "496a6f625f63b780ce849891868f2fad22fd49c6",
+        "rev": "443a7f2e7e118c4fc63b7fae05ab3080dd0e5c63",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -133,16 +133,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765363881,
-        "narHash": "sha256-3C3xWn8/2Zzr7sxVBmpc1H1QfxjNfta5IMFe3O9ZEPw=",
+        "lastModified": 1765311797,
+        "narHash": "sha256-mSD5Ob7a+T2RNjvPvOA1dkJHGVrNVl8ZOrAwBjKBDQo=",
         "owner": "NixOs",
         "repo": "nixpkgs",
-        "rev": "d2b1213bf5ec5e62d96b003ab4b5cbc42abfc0d0",
+        "rev": "09eb77e94fa25202af8f3e81ddc7353d9970ac1b",
         "type": "github"
       },
       "original": {
         "owner": "NixOs",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -162,22 +162,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1765472234,
-        "narHash": "sha256-9VvC20PJPsleGMewwcWYKGzDIyjckEz8uWmT0vCDYK0=",
-        "owner": "NixOs",
-        "repo": "nixpkgs",
-        "rev": "2fbfb1d73d239d2402a8fe03963e37aab15abe8b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOs",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "disko": "disko",
@@ -186,7 +170,6 @@
         "nixos-anywhere": "nixos-anywhere",
         "nixos-images": "nixos-images",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-unstable": "nixpkgs-unstable",
         "sops-nix": "sops-nix"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,7 @@
   description = "Home Lab / Home Server";
 
   inputs = {
-    nixpkgs.url = "github:NixOs/nixpkgs/nixos-25.05";
-    nixpkgs-unstable.url = "github:NixOs/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOs/nixpkgs/nixos-25.11";
     flake-parts.url = "github:hercules-ci/flake-parts";
     import-tree.url = "github:vic/import-tree";
     nixos-images = {
@@ -38,7 +37,6 @@
     flake-parts,
     import-tree,
     nixpkgs,
-    nixpkgs-unstable,
     ...
   }:
     flake-parts.lib.mkFlake {inherit inputs;} ({withSystem, ...}: {
@@ -58,24 +56,14 @@
         inputs',
         ...
       }: {
-        _module.args.pkgs = let
-          pkgsUnstable = import nixpkgs-unstable {
-            inherit system;
-          };
-        in
-          import nixpkgs {
-            inherit system;
-            config.allowUnfreePredicate = pkg:
-              builtins.elem (nixpkgs.lib.getName pkg) [
-                "netdata" # The UI is non OSS. It's under its own funny license.
-              ];
-            overlays = [
-              # Use unstable coredns. It's supports ordering plugins correctly
-              (prev: final: {
-                inherit (pkgsUnstable) coredns;
-              })
+        _module.args.pkgs = import nixpkgs {
+          inherit system;
+          config.allowUnfreePredicate = pkg:
+            builtins.elem (nixpkgs.lib.getName pkg) [
+              "netdata" # The UI is non OSS. It's under its own funny license.
             ];
-          };
+          overlays = [];
+        };
         formatter = pkgs.writeShellApplication {
           name = "alejandra-format-repo";
           runtimeInputs = [pkgs.alejandra];

--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,15 @@
             builtins.elem (nixpkgs.lib.getName pkg) [
               "netdata" # The UI is non OSS. It's under its own funny license.
             ];
-          overlays = [];
+          overlays = [
+            (final: prev: {
+              # HACK: `nixos-images` is not ready for 25.11 and still references
+              # the old zfsUnstable which has been removed. This works around
+              # the issue until the following PR gets merged:
+              # https://github.com/nix-community/nixos-images/pull/385
+              zfsUnstable = prev.zfs_unstable;
+            })
+          ];
         };
         formatter = pkgs.writeShellApplication {
           name = "alejandra-format-repo";

--- a/hosts/homelab/hardware-configuration.nix
+++ b/hosts/homelab/hardware-configuration.nix
@@ -30,7 +30,6 @@
 
     swapDevices = [];
 
-    nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
     hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
   };
 }

--- a/modules/dns/default.nix
+++ b/modules/dns/default.nix
@@ -1,5 +1,9 @@
-{self, ...}: {
-  flake.modules.nixos.dns = {
+{
+  self,
+  moduleWithSystem,
+  ...
+}: {
+  flake.modules.nixos.dns = moduleWithSystem ({self', ...}: {
     lib,
     config,
     pkgs,
@@ -14,7 +18,7 @@
       types
       ;
     inherit
-      (self.packages.${pkgs.system})
+      (self'.packages)
       coredns
       anudeepnd-allowlist
       stevenblack-blocklist
@@ -187,6 +191,6 @@
       networking.nameservers = ["127.0.0.1:${toString cfg.port}"];
       networking.firewall.allowedUDPPorts = [cfg.port];
     };
-  };
+  });
   flake.modules.nixos.default = self.modules.nixos.dns;
 }

--- a/modules/search/default.nix
+++ b/modules/search/default.nix
@@ -58,7 +58,7 @@
               favicon_resolver = "duckduckgo";
             };
           };
-          runInUwsgi = true;
+          configureUwsgi = true;
           uwsgiConfig = {
             http = "127.0.0.1:${builtins.toString cfg.port}";
             disable-logging = true; # It logs queries by default


### PR DESCRIPTION
It's time again. This will allow for a bunch of cleanup that we're overdue for. Off the top of my head I know that:

- We don't need to pull coredns from unstable anymore
- The NG deploy script is now default. We might be able to undo our early migration.